### PR TITLE
Heroku fix

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,5 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
   default from: 'from@example.com'
   layout 'mailer'
-  mail(to: User.email, subject: 'user invite')
 end


### PR DESCRIPTION
Removing `  # mail(to: User.email, subject: 'user invite')` from `ApplicationMailer`